### PR TITLE
Add: mock mode (--mock flag) for local development without eBPF/RPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/
+data/
+deploy.env

--- a/README.md
+++ b/README.md
@@ -1,95 +1,154 @@
 # NetworkTrafficControl
 
-NetworkTrafficControl is a Linux XDP/eBPF traffic monitor and controller. It attaches an XDP program to a network interface, streams packet events to a Go HTTP server, and exposes a small web UI plus API endpoints for managing blacklist and whitelist IP maps.
+NetworkTrafficControl is a Linux XDP/eBPF traffic monitor and controller. It attaches an XDP program to a network interface, streams packet events to a Go HTTP server, and exposes a web UI plus API endpoints for managing blacklist and whitelist IP maps.
 
 ## Features
 
 - XDP packet inspection for IPv4 and IPv6 traffic.
-- Blacklist support for dropping packets by source or destination IP.
+- Blacklist support for dropping packets by source IP.
 - Whitelist support for allowing traffic while marking events as skipped.
 - SSH traffic bypass on TCP port 22.
 - Ring buffer event stream from eBPF to user space.
 - Browser UI served from `client/web`.
 - HTTP API for event streaming and list management.
+- Blacklist and whitelist persisted to JSON file — survives restarts.
+- Mock mode (`--mock`) for local development without eBPF or Raspberry Pi.
+- YAML config file for port, timezone, interface, and persistence path.
 
 ## Repository Layout
 
 ```text
 .
-├── deploy.sh                 # Builds eBPF and Go artifacts, then copies them to execute/ or Raspberry Pi
+├── deploy.sh               # Build and deploy script (see targets below)
+├── deploy.env              # Local RPi connection config (gitignored, copy from deploy.env.example)
+├── deploy.env.example      # Template for deploy.env
+├── config.yaml             # Runtime configuration
 ├── eBPF/
-│   └── xdp_ring.bpf.c        # XDP/eBPF program
-├── client/
-│   ├── ntc/main.go           # Go entrypoint
-│   ├── httpapi/              # HTTP handlers and SSE endpoint
-│   ├── internal/bpf/         # eBPF loading, event parsing, map helpers
-│   └── web/                  # Static web UI
-└── execute/                  # Generated runtime artifacts after deploy.sh local
+│   └── xdp_ring.bpf.c      # XDP/eBPF program
+└── client/
+    ├── ntc/main.go          # Go entrypoint
+    ├── httpapi/             # HTTP handlers and SSE endpoint
+    ├── internal/
+    │   ├── bpf/             # eBPF loading, event parsing, map helpers
+    │   ├── clock/           # Timestamp conversion
+    │   ├── config/          # YAML config loader
+    │   ├── mock/            # Synthetic packet generator (mock mode)
+    │   ├── model/           # Shared types
+    │   └── persist/         # JSON persistence for blacklist/whitelist
+    └── web/                 # Static web UI
 ```
 
-## Requirements
+## Configuration
 
-- Linux with eBPF/XDP support.
-- Root privileges or equivalent capabilities to attach XDP programs.
-- Go 1.25 or newer, matching `client/go.mod`.
-- `clang` with BPF target support.
-- Kernel headers and libbpf headers available to compile the eBPF program.
+Edit `config.yaml` before running:
 
-On Debian/Ubuntu-like systems, the native packages are usually similar to:
+```yaml
+server:
+  port: 8086
+  timezone: Europe/Warsaw  # IANA timezone, empty = UTC
+
+network:
+  interfaces:
+    - wlan0  # interface to attach XDP to
+
+persistence:
+  path: ./data/lists.json  # path to blacklist/whitelist JSON file
+```
+
+## Local Development (mock mode, no RPi required)
+
+Run with a synthetic packet generator — no eBPF or Linux required:
 
 ```sh
-sudo apt install clang llvm linux-headers-$(uname -r) libbpf-dev
+cd /path/to/NetworkTrafficControl
+go run ./client/ntc --mock
 ```
 
-## Build
+Open the web UI at:
 
-Build for the local Linux machine:
-
-```sh
-./deploy.sh local
 ```
-
-This compiles:
-
-- `eBPF/xdp_ring.bpf.o`
-- `client/ntc/ntc`
-
-Then copies the runtime files into `execute/`.
-
-Build and copy to the Raspberry Pi target configured in `deploy.sh`:
-
-```sh
-./deploy.sh rpi
-```
-
-Before using the Raspberry Pi target, update `DEST` in `deploy.sh` to match your username, host, and destination directory.
-
-## Run
-
-After building locally:
-
-```sh
-cd execute
-sudo ./ntc
-```
-
-The server listens on:
-
-```text
 http://localhost:8086
 ```
 
-Open that URL in a browser to use the web UI.
+To use a custom config:
 
-## Network Interface
-
-The Go entrypoint currently attaches XDP to `wlan0`:
-
-```go
-mgr, err := bpf.Load("xdp_ring.bpf.o", "wlan0")
+```sh
+go run ./client/ntc --mock --config /path/to/config.yaml
 ```
 
-If your target interface has a different name, update `client/ntc/main.go` before building. Common names include `eth0`, `wlan0`, `enp3s0`, and `wlp2s0`.
+## Raspberry Pi — First Time Setup
+
+**1. Configure connection:**
+
+```sh
+cp deploy.env.example deploy.env
+# Edit deploy.env with your RPi host, user, and directory
+```
+
+**2. Set up SSH key (no password prompts):**
+
+```sh
+ssh-keygen -t ed25519   # if you don't have a key yet
+ssh-copy-id rpi@rpi.local
+```
+
+**3. Install dependencies on RPi:**
+
+```sh
+./deploy.sh rpi-install-dependencies
+```
+
+This installs: `clang`, `llvm`, `linux-headers`, `libbpf-dev`, `libc6-dev`, and Go.
+
+**4. Build and deploy:**
+
+```sh
+./deploy.sh rpi-build
+```
+
+Copies sources to RPi and compiles eBPF + Go on the device.
+
+**5. Install systemd service:**
+
+```sh
+./deploy.sh rpi-install-service
+```
+
+The service starts automatically on boot and restarts on failure.
+
+## Raspberry Pi — Managing the Service
+
+```sh
+ssh rpi@rpi.local 'sudo systemctl start ntc'
+ssh rpi@rpi.local 'sudo systemctl stop ntc'
+ssh rpi@rpi.local 'sudo systemctl restart ntc'
+ssh rpi@rpi.local 'sudo journalctl -u ntc -f'   # live logs
+```
+
+Open the web UI at:
+
+```
+http://rpi.local:8086
+```
+
+## Subsequent Deploys
+
+After making changes, rebuild and redeploy:
+
+```sh
+./deploy.sh rpi-build
+ssh rpi@rpi.local 'sudo systemctl restart ntc'
+```
+
+## deploy.sh Targets
+
+| Target | Description |
+|---|---|
+| `local` | Build eBPF and Go locally, copy to `execute/` |
+| `rpi` | Cross-compile on macOS, copy artifacts to RPi |
+| `rpi-build` | Copy sources to RPi, build eBPF and Go on device |
+| `rpi-install-dependencies` | Install all build dependencies on RPi |
+| `rpi-install-service` | Install and enable systemd service on RPi |
 
 ## API
 
@@ -114,60 +173,48 @@ Example event payload:
 }
 ```
 
-Possible actions are:
+Possible actions:
 
-- `PASS`: packet passed normally.
-- `DROP`: packet matched the blacklist and was dropped.
-- `SKIP`: packet matched the whitelist and was passed.
-- `SSH`: packet used TCP port 22 and was bypassed.
+| Action | Description |
+|---|---|
+| `PASS` | Packet passed normally |
+| `DROP` | Packet matched blacklist and was dropped |
+| `SKIP` | Packet matched whitelist and was passed |
+| `SSH` | TCP port 22 — bypassed |
 
 ### Blacklist
 
-Add an IP to the blacklist:
-
 ```sh
+# Add
 curl -X POST http://localhost:8086/blacklist \
   -H 'Content-Type: application/json' \
   -d '{"ip":"192.168.0.50"}'
-```
 
-Remove an IP from the blacklist:
-
-```sh
+# Remove
 curl -X DELETE 'http://localhost:8086/blacklist?ip=192.168.0.50'
-```
 
-List blacklisted IPs:
-
-```sh
+# List
 curl http://localhost:8086/blacklist
 ```
 
 ### Whitelist
 
-Add an IP to the whitelist:
-
 ```sh
+# Add
 curl -X POST http://localhost:8086/whitelist \
   -H 'Content-Type: application/json' \
   -d '{"ip":"192.168.0.20"}'
-```
 
-Remove an IP from the whitelist:
-
-```sh
+# Remove
 curl -X DELETE 'http://localhost:8086/whitelist?ip=192.168.0.20'
-```
 
-List whitelisted IPs:
-
-```sh
+# List
 curl http://localhost:8086/whitelist
 ```
 
 ## Notes
 
-- List changes are stored in eBPF maps and are not persisted after the process exits.
-- The blacklist and whitelist maps support IPv4 and IPv6 addresses.
-- The eBPF maps currently allow up to 1024 entries per list.
-- The static web UI is served from `./web`, so run `ntc` from the generated `execute/` directory unless you adjust the file paths.
+- Blacklist and whitelist are persisted to JSON and restored on restart.
+- Both lists support IPv4 and IPv6 addresses.
+- eBPF maps allow up to 1024 entries per list.
+- The server must be run from the directory containing `web/` and `xdp_ring.bpf.o` (handled automatically by `rpi-install-service`).

--- a/client/go.mod
+++ b/client/go.mod
@@ -4,4 +4,7 @@ go 1.25.0
 
 require github.com/cilium/ebpf v0.20.0
 
-require golang.org/x/sys v0.37.0 // indirect
+require (
+	golang.org/x/sys v0.37.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/client/go.sum
+++ b/client/go.sum
@@ -24,3 +24,6 @@ golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
 golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/client/httpapi/blacklist.go
+++ b/client/httpapi/blacklist.go
@@ -1,12 +1,13 @@
 package httpapi
 
 import (
-	"client/internal/bpf"
 	"encoding/json"
 	"net/http"
+
+	"client/internal/model"
 )
 
-func BlacklistHandler(mgr *bpf.Manager) http.HandlerFunc {
+func BlacklistHandler(mgr ListManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 
@@ -23,8 +24,9 @@ func BlacklistHandler(mgr *bpf.Manager) http.HandlerFunc {
 			}
 			json.NewEncoder(w).Encode(IpResponse{
 				OK:      true,
-				IP:      bpf.ParseIpKey(key),
-				Version: key.Version})
+				IP:      model.ParseIP(key),
+				Version: key.Version,
+			})
 
 		case http.MethodDelete:
 			ip := r.URL.Query().Get("ip")
@@ -32,7 +34,6 @@ func BlacklistHandler(mgr *bpf.Manager) http.HandlerFunc {
 				http.Error(w, "missing ip", 400)
 				return
 			}
-
 			key, err := mgr.RemoveFromBlackList(ip)
 			if err != nil {
 				http.Error(w, err.Error(), 400)
@@ -40,7 +41,9 @@ func BlacklistHandler(mgr *bpf.Manager) http.HandlerFunc {
 			}
 			json.NewEncoder(w).Encode(IpResponse{
 				OK: true,
-				IP: bpf.ParseIpKey(key)})
+				IP: model.ParseIP(key),
+			})
+
 		case http.MethodGet:
 			list, err := mgr.GetFromBlackList()
 			if err != nil {

--- a/client/httpapi/server.go
+++ b/client/httpapi/server.go
@@ -3,10 +3,19 @@ package httpapi
 import (
 	"net/http"
 
-	"client/internal/bpf"
+	"client/internal/model"
 )
 
-func NewServer(addr string, mgr *bpf.Manager, sse *SSE) *http.Server {
+type ListManager interface {
+	AddToBlackList(ip string) (model.Ip_Key, error)
+	RemoveFromBlackList(ip string) (model.Ip_Key, error)
+	GetFromBlackList() ([]model.IpEntry, error)
+	AddToWhiteList(ip string) (model.Ip_Key, error)
+	RemoveFromWhiteList(ip string) (model.Ip_Key, error)
+	GetFromWhiteList() ([]model.IpEntry, error)
+}
+
+func NewServer(addr string, mgr ListManager, sse *SSE) *http.Server {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/events", sse.Handler)

--- a/client/httpapi/whitelist.go
+++ b/client/httpapi/whitelist.go
@@ -1,12 +1,13 @@
 package httpapi
 
 import (
-	"client/internal/bpf"
 	"encoding/json"
 	"net/http"
+
+	"client/internal/model"
 )
 
-func WhitelistHandler(mgr *bpf.Manager) http.HandlerFunc {
+func WhitelistHandler(mgr ListManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 
@@ -23,8 +24,9 @@ func WhitelistHandler(mgr *bpf.Manager) http.HandlerFunc {
 			}
 			json.NewEncoder(w).Encode(IpResponse{
 				OK:      true,
-				IP:      bpf.ParseIpKey(key),
-				Version: key.Version})
+				IP:      model.ParseIP(key),
+				Version: key.Version,
+			})
 
 		case http.MethodDelete:
 			ip := r.URL.Query().Get("ip")
@@ -32,7 +34,6 @@ func WhitelistHandler(mgr *bpf.Manager) http.HandlerFunc {
 				http.Error(w, "missing ip", 400)
 				return
 			}
-
 			key, err := mgr.RemoveFromWhiteList(ip)
 			if err != nil {
 				http.Error(w, err.Error(), 400)
@@ -40,7 +41,9 @@ func WhitelistHandler(mgr *bpf.Manager) http.HandlerFunc {
 			}
 			json.NewEncoder(w).Encode(IpResponse{
 				OK: true,
-				IP: bpf.ParseIpKey(key)})
+				IP: model.ParseIP(key),
+			})
+
 		case http.MethodGet:
 			list, err := mgr.GetFromWhiteList()
 			if err != nil {

--- a/client/internal/bpf/listWrappers.go
+++ b/client/internal/bpf/listWrappers.go
@@ -5,11 +5,19 @@ import (
 )
 
 func (m *Manager) AddToBlackList(ip string) (model.Ip_Key, error) {
-	return AddIpToList(m.Blacklist, ip)
+	key, err := AddIpToList(m.Blacklist, ip)
+	if err == nil {
+		m.save()
+	}
+	return key, err
 }
 
 func (m *Manager) RemoveFromBlackList(ip string) (model.Ip_Key, error) {
-	return RemoveIpFrom(m.Blacklist, ip)
+	key, err := RemoveIpFrom(m.Blacklist, ip)
+	if err == nil {
+		m.save()
+	}
+	return key, err
 }
 
 func (m *Manager) GetFromBlackList() ([]model.IpEntry, error) {
@@ -17,11 +25,19 @@ func (m *Manager) GetFromBlackList() ([]model.IpEntry, error) {
 }
 
 func (m *Manager) AddToWhiteList(ip string) (model.Ip_Key, error) {
-	return AddIpToList(m.Whitelist, ip)
+	key, err := AddIpToList(m.Whitelist, ip)
+	if err == nil {
+		m.save()
+	}
+	return key, err
 }
 
 func (m *Manager) RemoveFromWhiteList(ip string) (model.Ip_Key, error) {
-	return RemoveIpFrom(m.Whitelist, ip)
+	key, err := RemoveIpFrom(m.Whitelist, ip)
+	if err == nil {
+		m.save()
+	}
+	return key, err
 }
 
 func (m *Manager) GetFromWhiteList() ([]model.IpEntry, error) {

--- a/client/internal/bpf/loader.go
+++ b/client/internal/bpf/loader.go
@@ -1,7 +1,10 @@
 package bpf
 
 import (
+	"log"
 	"net"
+
+	"client/internal/persist"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -14,9 +17,10 @@ type Manager struct {
 	Events    *ringbuf.Reader
 	Blacklist *ebpf.Map
 	Whitelist *ebpf.Map
+	store     *persist.Store
 }
 
-func Load(objPath, ifaceName string) (*Manager, error) {
+func Load(objPath, ifaceName string, store *persist.Store) (*Manager, error) {
 	spec, err := ebpf.LoadCollectionSpec(objPath)
 	if err != nil {
 		return nil, err
@@ -51,13 +55,63 @@ func Load(objPath, ifaceName string) (*Manager, error) {
 		return nil, err
 	}
 
-	return &Manager{
+	m := &Manager{
 		Coll:      coll,
 		Link:      lnk,
 		Events:    rd,
 		Blacklist: coll.Maps["blacklist"],
 		Whitelist: coll.Maps["whitelist"],
-	}, nil
+		store:     store,
+	}
+	if store != nil {
+		m.loadFromStore()
+	}
+	return m, nil
+}
+
+func (m *Manager) loadFromStore() {
+	bl, wl, err := m.store.Load()
+	if err != nil {
+		log.Printf("persist: load failed: %v", err)
+		return
+	}
+	for _, ip := range bl {
+		if _, err := AddIpToList(m.Blacklist, ip); err != nil {
+			log.Printf("persist: restore blacklist %s: %v", ip, err)
+		}
+	}
+	for _, ip := range wl {
+		if _, err := AddIpToList(m.Whitelist, ip); err != nil {
+			log.Printf("persist: restore whitelist %s: %v", ip, err)
+		}
+	}
+}
+
+func (m *Manager) save() {
+	if m.store == nil {
+		return
+	}
+	bl, err := GetIpFromList(m.Blacklist)
+	if err != nil {
+		log.Printf("persist: save blacklist: %v", err)
+		return
+	}
+	wl, err := GetIpFromList(m.Whitelist)
+	if err != nil {
+		log.Printf("persist: save whitelist: %v", err)
+		return
+	}
+	blIPs := make([]string, len(bl))
+	for i, e := range bl {
+		blIPs[i] = e.IP
+	}
+	wlIPs := make([]string, len(wl))
+	for i, e := range wl {
+		wlIPs[i] = e.IP
+	}
+	if err := m.store.Save(blIPs, wlIPs); err != nil {
+		log.Printf("persist: save failed: %v", err)
+	}
 }
 
 func (m *Manager) Close() {

--- a/client/internal/clock/clock.go
+++ b/client/internal/clock/clock.go
@@ -20,18 +20,7 @@ func New(tz string) *Clock {
 		}
 	}
 
-	data, err := os.ReadFile("/proc/uptime")
-	if err != nil {
-		panic(err)
-	}
-
-	fields := strings.Fields(string(data))
-	uptimeSec, err := strconv.ParseFloat(fields[0], 64)
-	if err != nil {
-		panic(err)
-	}
-
-	boot := time.Now().Add(-time.Duration(uptimeSec * float64(time.Second)))
+	boot := bootTime()
 
 	return &Clock{
 		boot: boot,
@@ -40,5 +29,28 @@ func New(tz string) *Clock {
 }
 
 func (c *Clock) FromTs(ts uint64) time.Time {
-	return c.boot.Add(time.Duration(ts)).In(c.loc) // remove In if want UTC
+	return c.boot.Add(time.Duration(ts)).In(c.loc)
+}
+
+// bootTime returns the system boot time derived from /proc/uptime.
+// On systems where /proc/uptime is unavailable (e.g. macOS in mock mode),
+// it falls back to the Unix epoch so that Unix-nanosecond timestamps
+// produced by the mock generator are interpreted correctly.
+func bootTime() time.Time {
+	data, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return time.Unix(0, 0)
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return time.Unix(0, 0)
+	}
+
+	uptimeSec, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return time.Unix(0, 0)
+	}
+
+	return time.Now().Add(-time.Duration(uptimeSec * float64(time.Second)))
 }

--- a/client/internal/config/config.go
+++ b/client/internal/config/config.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Server  ServerConfig  `yaml:"server"`
+	Network NetworkConfig `yaml:"network"`
+}
+
+type ServerConfig struct {
+	Port     int    `yaml:"port"`
+	Timezone string `yaml:"timezone"`
+}
+
+type NetworkConfig struct {
+	Interfaces []string `yaml:"interfaces"`
+}
+
+func (c *Config) ServerAddr() string {
+	return fmt.Sprintf(":%d", c.Server.Port)
+}
+
+var defaults = Config{
+	Server: ServerConfig{
+		Port:     8086,
+		Timezone: "Europe/Warsaw",
+	},
+	Network: NetworkConfig{
+		Interfaces: []string{"wlan0"},
+	},
+}
+
+func Load(path string) (*Config, error) {
+	cfg := defaults
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &cfg, nil
+		}
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+
+	return &cfg, nil
+}

--- a/client/internal/config/config.go
+++ b/client/internal/config/config.go
@@ -8,8 +8,13 @@ import (
 )
 
 type Config struct {
-	Server  ServerConfig  `yaml:"server"`
-	Network NetworkConfig `yaml:"network"`
+	Server      ServerConfig      `yaml:"server"`
+	Network     NetworkConfig     `yaml:"network"`
+	Persistence PersistenceConfig `yaml:"persistence"`
+}
+
+type PersistenceConfig struct {
+	Path string `yaml:"path"`
 }
 
 type ServerConfig struct {
@@ -32,6 +37,9 @@ var defaults = Config{
 	},
 	Network: NetworkConfig{
 		Interfaces: []string{"wlan0"},
+	},
+	Persistence: PersistenceConfig{
+		Path: "./data/lists.json",
 	},
 }
 

--- a/client/internal/mock/generator.go
+++ b/client/internal/mock/generator.go
@@ -1,0 +1,124 @@
+package mock
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"client/internal/model"
+)
+
+var ipv4Pool = []string{
+	"192.168.1.1", "192.168.1.100", "192.168.1.200",
+	"10.0.0.1", "10.0.0.50", "10.0.0.100",
+	"172.16.0.1", "172.16.0.50",
+	"8.8.8.8", "8.8.4.4", "1.1.1.1",
+	"52.0.0.1", "104.0.0.1", "151.101.0.1",
+	"185.199.108.1", "140.82.120.1",
+	"203.0.113.1", "198.51.100.1",
+}
+
+var ipv6Pool = []string{
+	"2001:db8::1", "2001:db8::2", "2001:db8::3",
+	"fe80::1", "fe80::2",
+	"2606:4700:4700::1111", "2001:4860:4860::8888",
+}
+
+// protos: TCP=6, UDP=17, ICMP=1
+var protos = []uint8{6, 6, 6, 17, 17, 1}
+
+// GenerateEvents produces synthetic packet events for local development.
+// Simulates normal traffic (~20 pkt/s) with periodic bursts every 15s.
+// Respects blacklist/whitelist from mgr when assigning actions.
+func GenerateEvents(ctx context.Context, mgr *Manager) <-chan model.Event {
+	out := make(chan model.Event, 64)
+	var seq atomic.Uint64
+
+	go func() {
+		defer close(out)
+
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		burstTicker := time.NewTicker(15 * time.Second)
+		defer burstTicker.Stop()
+
+		inBurst := false
+		burstEnd := time.Time{}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-burstTicker.C:
+				inBurst = true
+				burstEnd = time.Now().Add(2 * time.Second)
+			case t := <-ticker.C:
+				if inBurst && t.After(burstEnd) {
+					inBurst = false
+				}
+				count := 1
+				if inBurst {
+					count = 20
+				}
+				for i := 0; i < count; i++ {
+					e := newEvent(rng, mgr, seq.Add(1))
+					select {
+					case out <- e:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	return out
+}
+
+func newEvent(rng *rand.Rand, mgr *Manager, seq uint64) model.Event {
+	useIPv6 := rng.Intn(5) == 0
+
+	var src, dst [16]byte
+	var ipVersion uint8
+	var srcStr, dstStr string
+
+	if useIPv6 {
+		ipVersion = 6
+		srcStr = ipv6Pool[rng.Intn(len(ipv6Pool))]
+		dstStr = ipv6Pool[rng.Intn(len(ipv6Pool))]
+		copy(src[:], net.ParseIP(srcStr).To16())
+		copy(dst[:], net.ParseIP(dstStr).To16())
+	} else {
+		ipVersion = 4
+		srcStr = ipv4Pool[rng.Intn(len(ipv4Pool))]
+		dstStr = ipv4Pool[rng.Intn(len(ipv4Pool))]
+		copy(src[:4], net.ParseIP(srcStr).To4())
+		copy(dst[:4], net.ParseIP(dstStr).To4())
+	}
+
+	proto := protos[rng.Intn(len(protos))]
+
+	var action uint8
+	switch {
+	case mgr.IsBlacklisted(srcStr):
+		action = uint8(model.ActDrop)
+	case mgr.IsWhitelisted(srcStr):
+		action = uint8(model.ActSkip)
+	case proto == 6 && rng.Intn(30) == 0:
+		action = uint8(model.ActSSHBypass)
+	default:
+		action = uint8(model.ActPass)
+	}
+
+	return model.Event{
+		Ts:         uint64(time.Now().UnixNano()),
+		Seq:        seq,
+		Src:        src,
+		Dst:        dst,
+		Proto:      proto,
+		Action:     action,
+		Ip_Version: ipVersion,
+	}
+}

--- a/client/internal/mock/manager.go
+++ b/client/internal/mock/manager.go
@@ -2,22 +2,65 @@ package mock
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"sync"
 
 	"client/internal/model"
+	"client/internal/persist"
 )
 
 type Manager struct {
 	mu        sync.RWMutex
 	blacklist map[string]model.Ip_Key
 	whitelist map[string]model.Ip_Key
+	store     *persist.Store
 }
 
-func NewManager() *Manager {
-	return &Manager{
+func NewManager(store *persist.Store) *Manager {
+	m := &Manager{
 		blacklist: make(map[string]model.Ip_Key),
 		whitelist: make(map[string]model.Ip_Key),
+		store:     store,
+	}
+	if store != nil {
+		m.loadFromStore()
+	}
+	return m
+}
+
+func (m *Manager) loadFromStore() {
+	bl, wl, err := m.store.Load()
+	if err != nil {
+		log.Printf("persist: load failed: %v", err)
+		return
+	}
+	for _, ip := range bl {
+		if key, err := buildKey(ip); err == nil {
+			m.blacklist[ip] = key
+		}
+	}
+	for _, ip := range wl {
+		if key, err := buildKey(ip); err == nil {
+			m.whitelist[ip] = key
+		}
+	}
+}
+
+func (m *Manager) save() {
+	if m.store == nil {
+		return
+	}
+	bl := make([]string, 0, len(m.blacklist))
+	for ip := range m.blacklist {
+		bl = append(bl, ip)
+	}
+	wl := make([]string, 0, len(m.whitelist))
+	for ip := range m.whitelist {
+		wl = append(wl, ip)
+	}
+	if err := m.store.Save(bl, wl); err != nil {
+		log.Printf("persist: save failed: %v", err)
 	}
 }
 
@@ -28,6 +71,7 @@ func (m *Manager) AddToBlackList(ip string) (model.Ip_Key, error) {
 	}
 	m.mu.Lock()
 	m.blacklist[ip] = key
+	m.save()
 	m.mu.Unlock()
 	return key, nil
 }
@@ -39,6 +83,7 @@ func (m *Manager) RemoveFromBlackList(ip string) (model.Ip_Key, error) {
 	}
 	m.mu.Lock()
 	delete(m.blacklist, ip)
+	m.save()
 	m.mu.Unlock()
 	return key, nil
 }
@@ -56,6 +101,7 @@ func (m *Manager) AddToWhiteList(ip string) (model.Ip_Key, error) {
 	}
 	m.mu.Lock()
 	m.whitelist[ip] = key
+	m.save()
 	m.mu.Unlock()
 	return key, nil
 }
@@ -67,6 +113,7 @@ func (m *Manager) RemoveFromWhiteList(ip string) (model.Ip_Key, error) {
 	}
 	m.mu.Lock()
 	delete(m.whitelist, ip)
+	m.save()
 	m.mu.Unlock()
 	return key, nil
 }

--- a/client/internal/mock/manager.go
+++ b/client/internal/mock/manager.go
@@ -1,0 +1,118 @@
+package mock
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"client/internal/model"
+)
+
+type Manager struct {
+	mu        sync.RWMutex
+	blacklist map[string]model.Ip_Key
+	whitelist map[string]model.Ip_Key
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		blacklist: make(map[string]model.Ip_Key),
+		whitelist: make(map[string]model.Ip_Key),
+	}
+}
+
+func (m *Manager) AddToBlackList(ip string) (model.Ip_Key, error) {
+	key, err := buildKey(ip)
+	if err != nil {
+		return key, err
+	}
+	m.mu.Lock()
+	m.blacklist[ip] = key
+	m.mu.Unlock()
+	return key, nil
+}
+
+func (m *Manager) RemoveFromBlackList(ip string) (model.Ip_Key, error) {
+	key, err := buildKey(ip)
+	if err != nil {
+		return key, err
+	}
+	m.mu.Lock()
+	delete(m.blacklist, ip)
+	m.mu.Unlock()
+	return key, nil
+}
+
+func (m *Manager) GetFromBlackList() ([]model.IpEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return toEntries(m.blacklist), nil
+}
+
+func (m *Manager) AddToWhiteList(ip string) (model.Ip_Key, error) {
+	key, err := buildKey(ip)
+	if err != nil {
+		return key, err
+	}
+	m.mu.Lock()
+	m.whitelist[ip] = key
+	m.mu.Unlock()
+	return key, nil
+}
+
+func (m *Manager) RemoveFromWhiteList(ip string) (model.Ip_Key, error) {
+	key, err := buildKey(ip)
+	if err != nil {
+		return key, err
+	}
+	m.mu.Lock()
+	delete(m.whitelist, ip)
+	m.mu.Unlock()
+	return key, nil
+}
+
+func (m *Manager) GetFromWhiteList() ([]model.IpEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return toEntries(m.whitelist), nil
+}
+
+func (m *Manager) IsBlacklisted(ip string) bool {
+	m.mu.RLock()
+	_, ok := m.blacklist[ip]
+	m.mu.RUnlock()
+	return ok
+}
+
+func (m *Manager) IsWhitelisted(ip string) bool {
+	m.mu.RLock()
+	_, ok := m.whitelist[ip]
+	m.mu.RUnlock()
+	return ok
+}
+
+func (m *Manager) Close() {}
+
+func buildKey(ipStr string) (model.Ip_Key, error) {
+	var key model.Ip_Key
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return key, fmt.Errorf("invalid IP: %s", ipStr)
+	}
+	if v4 := ip.To4(); v4 != nil {
+		key.Version = 4
+		copy(key.Address[:4], v4)
+		return key, nil
+	}
+	key.Version = 6
+	copy(key.Address[:], ip.To16())
+	return key, nil
+}
+
+func toEntries(m map[string]model.Ip_Key) []model.IpEntry {
+	result := make([]model.IpEntry, 0, len(m))
+	for ip, key := range m {
+		result = append(result, model.IpEntry{IP: ip, Version: key.Version})
+	}
+	return result
+}

--- a/client/internal/model/types.go
+++ b/client/internal/model/types.go
@@ -1,5 +1,7 @@
 package model
 
+import "net"
+
 type Event struct {
 	Ts  uint64
 	Seq uint64
@@ -70,6 +72,13 @@ func ProtoString(p uint8) string {
 type Ip_Key struct {
 	Version uint8
 	Address [16]byte
+}
+
+func ParseIP(k Ip_Key) string {
+	if k.Version == 4 {
+		return net.IP(k.Address[:4]).String()
+	}
+	return net.IP(k.Address[:16]).String()
 }
 
 type IpEntry struct {

--- a/client/internal/persist/store.go
+++ b/client/internal/persist/store.go
@@ -1,0 +1,60 @@
+package persist
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type Store struct {
+	mu   sync.Mutex
+	path string
+}
+
+type data struct {
+	Blacklist []string `json:"blacklist"`
+	Whitelist []string `json:"whitelist"`
+}
+
+func New(path string) (*Store, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	return &Store{path: path}, nil
+}
+
+func (s *Store) Load() (blacklist, whitelist []string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var d data
+	if err := json.Unmarshal(b, &d); err != nil {
+		return nil, nil, err
+	}
+	return d.Blacklist, d.Whitelist, nil
+}
+
+func (s *Store) Save(blacklist, whitelist []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, err := json.MarshalIndent(data{Blacklist: blacklist, Whitelist: whitelist}, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}

--- a/client/ntc/main.go
+++ b/client/ntc/main.go
@@ -16,6 +16,7 @@ import (
 	"client/internal/config"
 	"client/internal/mock"
 	"client/internal/model"
+	"client/internal/persist"
 )
 
 func main() {
@@ -40,9 +41,14 @@ func main() {
 	var mgr httpapi.ListManager
 	var events <-chan model.Event
 
+	store, err := persist.New(cfg.Persistence.Path)
+	if err != nil {
+		log.Fatalf("persist: %v", err)
+	}
+
 	if *mockMode {
 		log.Println("Starting in mock mode — synthetic traffic generator active")
-		m := mock.NewManager()
+		m := mock.NewManager(store)
 		mgr = m
 		events = mock.GenerateEvents(ctx, m)
 	} else {

--- a/client/ntc/main.go
+++ b/client/ntc/main.go
@@ -13,15 +13,22 @@ import (
 	"client/httpapi"
 	"client/internal/bpf"
 	"client/internal/clock"
+	"client/internal/config"
 	"client/internal/mock"
 	"client/internal/model"
 )
 
 func main() {
 	mockMode := flag.Bool("mock", false, "run with synthetic packet generator (no eBPF required)")
+	configPath := flag.String("config", "config.yaml", "path to YAML config file")
 	flag.Parse()
 
-	clk := clock.New("Europe/Warsaw")
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	clk := clock.New(cfg.Server.Timezone)
 
 	ctx, stop := signal.NotifyContext(
 		context.Background(),
@@ -39,7 +46,8 @@ func main() {
 		mgr = m
 		events = mock.GenerateEvents(ctx, m)
 	} else {
-		m, err := bpf.Load("xdp_ring.bpf.o", "wlan0")
+		iface := cfg.Network.Interfaces[0]
+		m, err := bpf.Load("xdp_ring.bpf.o", iface)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -72,11 +80,11 @@ func main() {
 		}
 	}()
 
-	port := ":8086"
-	srv := httpapi.NewServer(port, mgr, sse)
+	addr := cfg.ServerAddr()
+	srv := httpapi.NewServer(addr, mgr, sse)
 
 	go func() {
-		log.Println("HTTP listening on" + port)
+		log.Printf("HTTP listening on %s", addr)
 		if err := srv.ListenAndServe(); err != nil && err.Error() != "http: Server closed" {
 			log.Fatal(err)
 		}

--- a/client/ntc/main.go
+++ b/client/ntc/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"log"
 	"os"
 	"os/signal"
@@ -12,13 +13,16 @@ import (
 	"client/httpapi"
 	"client/internal/bpf"
 	"client/internal/clock"
+	"client/internal/mock"
 	"client/internal/model"
 )
 
 func main() {
-	// Empty if UTC
+	mockMode := flag.Bool("mock", false, "run with synthetic packet generator (no eBPF required)")
+	flag.Parse()
+
 	clk := clock.New("Europe/Warsaw")
-	// Graceful shutdown context
+
 	ctx, stop := signal.NotifyContext(
 		context.Background(),
 		os.Interrupt,
@@ -26,29 +30,28 @@ func main() {
 	)
 	defer stop()
 
-	// --- Load BPF + attach XDP ---
-	mgr, err := bpf.Load("xdp_ring.bpf.o", "wlan0")
-	if err != nil {
-		log.Fatal(err)
+	var mgr httpapi.ListManager
+	var events <-chan model.Event
+
+	if *mockMode {
+		log.Println("Starting in mock mode — synthetic traffic generator active")
+		m := mock.NewManager()
+		mgr = m
+		events = mock.GenerateEvents(ctx, m)
+	} else {
+		m, err := bpf.Load("xdp_ring.bpf.o", "wlan0")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer m.Close()
+		mgr = m
+		events = bpf.ReadEvents(ctx, m.Events)
 	}
-	defer mgr.Close()
 
-	// SECOND INTERFACE
-
-	// mgr2, err := bpf.Load("xdp_ring.bpf.o", "eth0")
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// defer mgr2.Close()
-	// --- Create SSE hub ---
 	sse := httpapi.NewSSE()
-
-	// --- Start ringbuf reader ---
-	events := bpf.ReadEvents(ctx, mgr.Events)
 
 	go func() {
 		for e := range events {
-
 			eventTime := clk.FromTs(e.Ts)
 
 			out := model.OutEvent{
@@ -69,29 +72,7 @@ func main() {
 		}
 	}()
 
-	// events2 := bpf.ReadEvents(ctx, mgr2.Events)
-	// go func() {
-	// 	for e := range events2 {
-
-	// 		out := model.OutEvent{
-	// 			Ts:    e.Ts,
-	// 			Seq:   e.Seq,
-	// 			Src:   bpf.Uint32ToIP(e.Src),
-	// 			Dst:   bpf.Uint32ToIP(e.Dst),
-	// 			Proto: e.Proto,
-	// 		}
-
-	// 		j, err := json.Marshal(out)
-	// 		if err != nil {
-	// 			continue
-	// 		}
-
-	// 		sse.Broadcast(j)
-	// 	}
-	// }()
-
 	port := ":8086"
-	// --- Create HTTP server ---
 	srv := httpapi.NewServer(port, mgr, sse)
 
 	go func() {
@@ -101,7 +82,6 @@ func main() {
 		}
 	}()
 
-	// --- Wait for shutdown ---
 	<-ctx.Done()
 	log.Println("Shutting down...")
 
@@ -109,8 +89,4 @@ func main() {
 	defer cancel()
 
 	_ = srv.Shutdown(shutdownCtx)
-
-	mgr.Close() // ← this is required
-
-	return
 }

--- a/client/ntc/main.go
+++ b/client/ntc/main.go
@@ -53,7 +53,7 @@ func main() {
 		events = mock.GenerateEvents(ctx, m)
 	} else {
 		iface := cfg.Network.Interfaces[0]
-		m, err := bpf.Load("xdp_ring.bpf.o", iface)
+		m, err := bpf.Load("xdp_ring.bpf.o", iface, store)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/client/web/app.js
+++ b/client/web/app.js
@@ -68,10 +68,10 @@ function renderList(data) {
 
 	for (const ip of data) {
 		const li = document.createElement('li');
-		li.textContent = ip;
+		li.textContent = ip.ip;
 
 		li.onclick = () => {
-			ipInputEl.value = ip;
+			ipInputEl.value = ip.ip;
 		};
 
 		listEl.appendChild(li);

--- a/client/web/app.js
+++ b/client/web/app.js
@@ -151,7 +151,7 @@ filterEl.addEventListener('input', () => {
 	countEl.textContent = '0';
 })
 
-const es = new EventSource('http://192.168.0.143:8086/events');
+const es = new EventSource(`${window.location.origin}/events`);
 es.onopen = () => setStatus(true)
 es.onerror = () => setStatus(false)
 es.onmessage = (msg) => {

--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ network:
 #   url: http://localhost:8428
 #   push_interval_seconds: 15
 
-# persistence:
-#   path: ./data/lists.json
+persistence:
+  path: ./data/lists.json
 
 # alerts:
 #   telegram:

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,22 @@
+server:
+  port: 8086
+  timezone: Europe/Warsaw  # IANA timezone, empty = UTC
+
+network:
+  interfaces:
+    - wlan0  # interfaces to attach XDP to
+
+# Future sections (uncomment when features are implemented):
+
+# victoriametrics:
+#   url: http://localhost:8428
+#   push_interval_seconds: 15
+
+# persistence:
+#   path: ./data/lists.json
+
+# alerts:
+#   telegram:
+#     bot_token: ""
+#     chat_id: ""
+#   webhook_url: ""

--- a/deploy.env.example
+++ b/deploy.env.example
@@ -1,0 +1,3 @@
+RPI_HOST=rpi.local
+RPI_USER=rpi
+RPI_DIR=/home/rpi/ntc

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,12 +6,28 @@ TARGET="${1:-local}"
 
 cd "$(dirname "$0")"
 
+if [ -f deploy.env ]; then
+    set -a
+    source deploy.env
+    set +a
+fi
+
 echo "[*] Target: $TARGET"
+
+RPI_HOST="${RPI_HOST:-rpi.local}"
+RPI_USER="${RPI_USER:-rpi}"
+RPI_DIR="${RPI_DIR:-/home/${RPI_USER}/ntc}"
 
 if [ "$TARGET" = "rpi" ]; then
     GOARCH=arm64
     BPF_ARCH=arm64
-    DEST="admin@192.168.0.143:/home/admin/execute/"
+    DEST="${RPI_USER}@${RPI_HOST}:${RPI_DIR}/"
+elif [ "$TARGET" = "rpi-install-dependencies" ]; then
+    :
+elif [ "$TARGET" = "rpi-install-service" ]; then
+    :
+elif [ "$TARGET" = "rpi-build" ]; then
+    :
 elif [ "$TARGET" = "local" ]; then
     GOARCH=amd64
     BPF_ARCH=x86
@@ -19,6 +35,92 @@ elif [ "$TARGET" = "local" ]; then
 else
     echo "Unknown target: $TARGET"
     exit 1
+fi
+
+if [ "$TARGET" = "rpi-install-service" ]; then
+    echo "[*] Installing ntc systemd service on RPi..."
+    ssh "${RPI_USER}@${RPI_HOST}" "sudo tee /etc/systemd/system/ntc.service > /dev/null << 'EOF'
+[Unit]
+Description=Network Traffic Control
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${RPI_DIR}
+ExecStart=${RPI_DIR}/ntc
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    sudo systemctl daemon-reload
+    sudo systemctl enable ntc
+    sudo systemctl restart ntc
+    "
+    echo "[✓] Done"
+    echo ""
+    echo "    sudo systemctl start ntc"
+    echo "    sudo systemctl stop ntc"
+    echo "    sudo systemctl restart ntc"
+    echo "    sudo journalctl -u ntc -f"
+    exit 0
+fi
+
+if [ "$TARGET" = "rpi-install-dependencies" ]; then
+    echo "[*] Installing dependencies on RPi..."
+    ssh "${RPI_USER}@${RPI_HOST}" "
+        set -e
+        sudo apt-get update -qq
+
+        echo '[*] Installing clang, llvm, linux headers...'
+        sudo apt-get install -y clang llvm linux-headers-\$(uname -r) libbpf-dev libc6-dev
+
+        echo '[*] Installing Go...'
+        if ! command -v go &>/dev/null; then
+            GO_VERSION=1.23.4
+            curl -fsSL https://go.dev/dl/go\${GO_VERSION}.linux-arm64.tar.gz -o /tmp/go.tar.gz
+            sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+            rm /tmp/go.tar.gz
+            echo 'export PATH=\$PATH:/usr/local/go/bin' >> ~/.profile
+            echo 'export PATH=\$PATH:/usr/local/go/bin' >> ~/.bashrc
+        else
+            echo 'Go already installed: '\$(go version)
+        fi
+    "
+    echo "[✓] Done — reconnect SSH or run: source ~/.profile"
+    exit 0
+fi
+
+if [ "$TARGET" = "rpi-build" ]; then
+    echo "[*] Copying sources to RPi..."
+    ssh "${RPI_USER}@${RPI_HOST}" "mkdir -p ${RPI_DIR}"
+    rsync -az --delete --exclude='data/' --exclude='*.o' --exclude='ntc_bin' \
+        client/ "${RPI_USER}@${RPI_HOST}:${RPI_DIR}/client/"
+    rsync -az eBPF/ "${RPI_USER}@${RPI_HOST}:${RPI_DIR}/eBPF/"
+    scp config.yaml "${RPI_USER}@${RPI_HOST}:${RPI_DIR}/"
+
+    echo "[*] Building eBPF on RPi..."
+    ssh "${RPI_USER}@${RPI_HOST}" "
+        cd ${RPI_DIR}/eBPF &&
+        clang -O2 -g -target bpf -D__TARGET_ARCH_arm64 \
+          -I/usr/include/aarch64-linux-gnu \
+          -c xdp_ring.bpf.c -o xdp_ring.bpf.o
+    "
+
+    echo "[*] Building Go on RPi..."
+    ssh "${RPI_USER}@${RPI_HOST}" "
+        cd ${RPI_DIR}/client &&
+        /usr/local/go/bin/go build -o ${RPI_DIR}/ntc ./ntc &&
+        chmod +x ${RPI_DIR}/ntc &&
+        cp ${RPI_DIR}/eBPF/xdp_ring.bpf.o ${RPI_DIR}/xdp_ring.bpf.o &&
+        cp -r ${RPI_DIR}/client/web ${RPI_DIR}/web
+    "
+
+    echo "[✓] Done"
+    echo ""
+    echo "    Run: ssh ${RPI_USER}@${RPI_HOST} 'cd ${RPI_DIR} && sudo ./ntc'"
+    exit 0
 fi
 
 # --- Compile eBPF ---
@@ -31,7 +133,7 @@ cd ..
 # --- Compile Go ---
 echo "[*] Compiling Go..."
 cd client
-GOOS=linux GOARCH=$GOARCH go build -o ntc ./ntc
+GOOS=linux GOARCH=$GOARCH go build -o ntc_bin ./ntc
 cd ..
 
 # --- Prepare local execute dir ---
@@ -44,11 +146,20 @@ fi
 echo "[*] Copying artifacts..."
 
 if [ "$TARGET" = "rpi" ]; then
-    scp -r client/web eBPF/xdp_ring.bpf.o client/ntc/ntc "$DEST"
+    ssh "${RPI_USER}@${RPI_HOST}" "mkdir -p ${RPI_DIR}"
+    scp -r client/web eBPF/xdp_ring.bpf.o client/ntc_bin config.yaml "$DEST"
+    ssh "${RPI_USER}@${RPI_HOST}" "mv ${RPI_DIR}/ntc_bin ${RPI_DIR}/ntc && chmod +x ${RPI_DIR}/ntc"
 else
     cp -r client/web "$DEST"
     cp eBPF/xdp_ring.bpf.o "$DEST"
-    cp client/ntc/ntc "$DEST"
+    cp client/ntc_bin "${DEST}ntc"
+    cp config.yaml "$DEST"
 fi
 
-echo "[✓] Done"
+echo "[✓] Done — deployed to $DEST"
+echo ""
+if [ "$TARGET" = "rpi" ]; then
+    echo "    Run: ssh ${RPI_USER}@${RPI_HOST} '${RPI_DIR}/ntc'"
+else
+    echo "    Run: ./execute/ntc"
+fi


### PR DESCRIPTION
Add mock mode (--mock flag) for local development without eBPF/Raspberry Pi

- Add ListManager interface to httpapi, decouple handlers from *bpf.Manager
- Add model.ParseIP utility, remove bpf dependency from httpapi handlers
- Add internal/mock package: in-memory list manager + synthetic packet generator
- Generator produces ~20 pkt/s IPv4/IPv6 traffic with periodic bursts, respects blacklist/whitelist
- Fix clock.New to not panic when /proc/uptime is unavailable (macOS)