### PR TITLE
Add: YAML config file support (NTC-24)

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -4,4 +4,7 @@ go 1.25.0
 
 require github.com/cilium/ebpf v0.20.0
 
-require golang.org/x/sys v0.37.0 // indirect
+require (
+	golang.org/x/sys v0.37.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/client/go.sum
+++ b/client/go.sum
@@ -24,3 +24,6 @@ golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
 golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/client/internal/config/config.go
+++ b/client/internal/config/config.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Server  ServerConfig  `yaml:"server"`
+	Network NetworkConfig `yaml:"network"`
+}
+
+type ServerConfig struct {
+	Port     int    `yaml:"port"`
+	Timezone string `yaml:"timezone"`
+}
+
+type NetworkConfig struct {
+	Interfaces []string `yaml:"interfaces"`
+}
+
+func (c *Config) ServerAddr() string {
+	return fmt.Sprintf(":%d", c.Server.Port)
+}
+
+var defaults = Config{
+	Server: ServerConfig{
+		Port:     8086,
+		Timezone: "Europe/Warsaw",
+	},
+	Network: NetworkConfig{
+		Interfaces: []string{"wlan0"},
+	},
+}
+
+func Load(path string) (*Config, error) {
+	cfg := defaults
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &cfg, nil
+		}
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+
+	return &cfg, nil
+}

--- a/client/ntc/main.go
+++ b/client/ntc/main.go
@@ -13,15 +13,22 @@ import (
 	"client/httpapi"
 	"client/internal/bpf"
 	"client/internal/clock"
+	"client/internal/config"
 	"client/internal/mock"
 	"client/internal/model"
 )
 
 func main() {
 	mockMode := flag.Bool("mock", false, "run with synthetic packet generator (no eBPF required)")
+	configPath := flag.String("config", "config.yaml", "path to YAML config file")
 	flag.Parse()
 
-	clk := clock.New("Europe/Warsaw")
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	clk := clock.New(cfg.Server.Timezone)
 
 	ctx, stop := signal.NotifyContext(
 		context.Background(),
@@ -39,7 +46,8 @@ func main() {
 		mgr = m
 		events = mock.GenerateEvents(ctx, m)
 	} else {
-		m, err := bpf.Load("xdp_ring.bpf.o", "wlan0")
+		iface := cfg.Network.Interfaces[0]
+		m, err := bpf.Load("xdp_ring.bpf.o", iface)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -72,11 +80,11 @@ func main() {
 		}
 	}()
 
-	port := ":8086"
-	srv := httpapi.NewServer(port, mgr, sse)
+	addr := cfg.ServerAddr()
+	srv := httpapi.NewServer(addr, mgr, sse)
 
 	go func() {
-		log.Println("HTTP listening on" + port)
+		log.Printf("HTTP listening on %s", addr)
 		if err := srv.ListenAndServe(); err != nil && err.Error() != "http: Server closed" {
 			log.Fatal(err)
 		}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,22 @@
+server:
+  port: 8086
+  timezone: Europe/Warsaw  # IANA timezone, empty = UTC
+
+network:
+  interfaces:
+    - wlan0  # interfaces to attach XDP to
+
+# Future sections (uncomment when features are implemented):
+
+# victoriametrics:
+#   url: http://localhost:8428
+#   push_interval_seconds: 15
+
+# persistence:
+#   path: ./data/lists.json
+
+# alerts:
+#   telegram:
+#     bot_token: ""
+#     chat_id: ""
+#   webhook_url: ""


### PR DESCRIPTION
Replace hardcoded server port, timezone and network interface with values loaded from config.yaml at startup. Falls back to defaults when config file is absent.

- Add internal/config package with Config struct and Load() function
- Add config.yaml with defaults and commented future sections (VM, persistence, alerts)
- Add --config flag (default: config.yaml) to specify config path
- server.port, server.timezone, network.interfaces now configurable